### PR TITLE
fix(*): include all bundled files

### DIFF
--- a/packages/apply/package.json
+++ b/packages/apply/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-apply.umd.js",
   "jsnext:main": "dist/apr-apply.es.js",
   "module": "dist/apr-apply.es.js",

--- a/packages/asyncify/package.json
+++ b/packages/asyncify/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-asyncify.umd.js",
   "jsnext:main": "dist/apr-asyncify.es.js",
   "module": "dist/apr-asyncify.es.js",

--- a/packages/awaitify/package.json
+++ b/packages/awaitify/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-awaitify.umd.js",
   "jsnext:main": "dist/apr-awaitify.es.js",
   "module": "dist/apr-awaitify.es.js",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-compose.umd.js",
   "jsnext:main": "dist/apr-compose.es.js",
   "module": "dist/apr-compose.es.js",

--- a/packages/concat/package.json
+++ b/packages/concat/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-concat.umd.js",
   "jsnext:main": "dist/apr-concat.es.js",
   "module": "dist/apr-concat.es.js",

--- a/packages/constant/package.json
+++ b/packages/constant/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-constant.umd.js",
   "jsnext:main": "dist/apr-constant.es.js",
   "module": "dist/apr-constant.es.js",

--- a/packages/dir/package.json
+++ b/packages/dir/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-dir.umd.js",
   "jsnext:main": "dist/apr-dir.es.js",
   "module": "dist/apr-dir.es.js",

--- a/packages/engine-back/package.json
+++ b/packages/engine-back/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-back.umd.js",
   "jsnext:main": "dist/apr-engine-back.es.js",
   "module": "dist/apr-engine-back.es.js",

--- a/packages/engine-console/package.json
+++ b/packages/engine-console/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-console.umd.js",
   "jsnext:main": "dist/apr-engine-console.es.js",
   "module": "dist/apr-engine-console.es.js",

--- a/packages/engine-each/package.json
+++ b/packages/engine-each/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-each.umd.js",
   "jsnext:main": "dist/apr-engine-each.es.js",
   "module": "dist/apr-engine-each.es.js",

--- a/packages/engine-iterator/package.json
+++ b/packages/engine-iterator/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-iterator.umd.js",
   "jsnext:main": "dist/apr-engine-iterator.es.js",
   "module": "dist/apr-engine-iterator.es.js",

--- a/packages/engine-repeat/package.json
+++ b/packages/engine-repeat/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-repeat.umd.js",
   "jsnext:main": "dist/apr-engine-repeat.es.js",
   "module": "dist/apr-engine-repeat.es.js",

--- a/packages/engine-run/package.json
+++ b/packages/engine-run/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-run.umd.js",
   "jsnext:main": "dist/apr-engine-run.es.js",
   "module": "dist/apr-engine-run.es.js",

--- a/packages/engine-sum/package.json
+++ b/packages/engine-sum/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-sum.umd.js",
   "jsnext:main": "dist/apr-engine-sum.es.js",
   "module": "dist/apr-engine-sum.es.js",

--- a/packages/engine-until/package.json
+++ b/packages/engine-until/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-engine-until.umd.js",
   "jsnext:main": "dist/apr-engine-until.es.js",
   "module": "dist/apr-engine-until.es.js",

--- a/packages/every/package.json
+++ b/packages/every/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-every.umd.js",
   "jsnext:main": "dist/apr-every.es.js",
   "module": "dist/apr-every.es.js",

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-filter.umd.js",
   "jsnext:main": "dist/apr-filter.es.js",
   "module": "dist/apr-filter.es.js",

--- a/packages/find/package.json
+++ b/packages/find/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-find.umd.js",
   "jsnext:main": "dist/apr-find.es.js",
   "module": "dist/apr-find.es.js",

--- a/packages/for-each/package.json
+++ b/packages/for-each/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-for-each.umd.js",
   "jsnext:main": "dist/apr-for-each.es.js",
   "module": "dist/apr-for-each.es.js",

--- a/packages/intercept/package.json
+++ b/packages/intercept/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-intercept.umd.js",
   "jsnext:main": "dist/apr-intercept.es.js",
   "module": "dist/apr-intercept.es.js",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-log.umd.js",
   "jsnext:main": "dist/apr-log.es.js",
   "module": "dist/apr-log.es.js",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -27,9 +27,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-main.umd.js",
   "jsnext:main": "dist/apr-main.es.js",
   "module": "dist/apr-main.es.js",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-map.umd.js",
   "jsnext:main": "dist/apr-map.es.js",
   "module": "dist/apr-map.es.js",

--- a/packages/parallel/package.json
+++ b/packages/parallel/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-parallel.umd.js",
   "jsnext:main": "dist/apr-parallel.es.js",
   "module": "dist/apr-parallel.es.js",

--- a/packages/reduce/package.json
+++ b/packages/reduce/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-reduce.umd.js",
   "jsnext:main": "dist/apr-reduce.es.js",
   "module": "dist/apr-reduce.es.js",

--- a/packages/reflect/package.json
+++ b/packages/reflect/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-reflect.umd.js",
   "jsnext:main": "dist/apr-reflect.es.js",
   "module": "dist/apr-reflect.es.js",

--- a/packages/reject/package.json
+++ b/packages/reject/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-reject.umd.js",
   "jsnext:main": "dist/apr-reject.es.js",
   "module": "dist/apr-reject.es.js",

--- a/packages/seq/package.json
+++ b/packages/seq/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-seq.umd.js",
   "jsnext:main": "dist/apr-seq.es.js",
   "module": "dist/apr-seq.es.js",

--- a/packages/series/package.json
+++ b/packages/series/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-series.umd.js",
   "jsnext:main": "dist/apr-series.es.js",
   "module": "dist/apr-series.es.js",

--- a/packages/some/package.json
+++ b/packages/some/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-some.umd.js",
   "jsnext:main": "dist/apr-some.es.js",
   "module": "dist/apr-some.es.js",

--- a/packages/sort-by/package.json
+++ b/packages/sort-by/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-sort-by.umd.js",
   "jsnext:main": "dist/apr-sort-by.es.js",
   "module": "dist/apr-sort-by.es.js",

--- a/packages/test-get-ittr/package.json
+++ b/packages/test-get-ittr/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-test-get-ittr.umd.js",
   "jsnext:main": "dist/apr-test-get-ittr.es.js",
   "module": "dist/apr-test-get-ittr.es.js",

--- a/packages/test-scheduler/package.json
+++ b/packages/test-scheduler/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-test-scheduler.umd.js",
   "jsnext:main": "dist/apr-test-scheduler.es.js",
   "module": "dist/apr-test-scheduler.es.js",

--- a/packages/test-timeout/package.json
+++ b/packages/test-timeout/package.json
@@ -24,9 +24,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-test-timeout.umd.js",
   "jsnext:main": "dist/apr-test-timeout.es.js",
   "module": "dist/apr-test-timeout.es.js",

--- a/packages/times/package.json
+++ b/packages/times/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-times.umd.js",
   "jsnext:main": "dist/apr-times.es.js",
   "module": "dist/apr-times.es.js",

--- a/packages/until/package.json
+++ b/packages/until/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-until.umd.js",
   "jsnext:main": "dist/apr-until.es.js",
   "module": "dist/apr-until.es.js",

--- a/packages/waterfall/package.json
+++ b/packages/waterfall/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-waterfall.umd.js",
   "jsnext:main": "dist/apr-waterfall.es.js",
   "module": "dist/apr-waterfall.es.js",

--- a/packages/whilst/package.json
+++ b/packages/whilst/package.json
@@ -25,9 +25,7 @@
   "bugs": "https://github.com/ramitos/apr/issues",
   "author": "Sérgio Ramos <mail@sergioramos.me> (http://sergioramos.me)",
   "repository": "ramitos/apr",
-  "files": [
-    "files"
-  ],
+  "files": ["dist"],
   "main": "dist/apr-whilst.umd.js",
   "jsnext:main": "dist/apr-whilst.es.js",
   "module": "dist/apr-whilst.es.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,6 +2729,13 @@ diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+dir-glob@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
+
 disparity@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/disparity/-/disparity-2.0.0.tgz#57ddacb47324ae5f58d2cc0da886db4ce9eeb718"
@@ -3884,6 +3891,18 @@ globby@^6.0.0, globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 got@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/got/-/got-3.3.1.tgz#e5d0ed4af55fc3eef4d56007769d98192bcb2eca"
@@ -4234,6 +4253,11 @@ ignore-by-default@^1.0.0:
 ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 import-lazy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Fixes #9 
npm only automatically included the UMD bundle because it was specified in `main`.
Now that all of `dist/` is included, the other bundles specified in `jsnext:main` and `module` will also be there.
There is no `files/` from what I could see.
Tested by `npm pack`ing `apr-intercept` from this branch and using it in a repo that had the issue #9 - verified that it is fixed.
If any of the `packages/*` has a special build setup different from `apr-intercept` in some way let me know because it may break something, you'll know better than me @sergioramos :sweat_smile: 